### PR TITLE
Add markymark pod and support markdown in UILabel

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -10,6 +10,7 @@ def shared_pods
   pod 'Tabman', '1.6.0'
   pod 'Alamofire', '~> 4.6'
   pod 'Alamofire-SwiftyJSON'
+  pod 'markymark'
 end
 
 target 'ThaiTechEventsCalendar' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,6 +5,7 @@ PODS:
     - SwiftyJSON (~> 4.0.0)
   - AutoInsetter (1.2.1)
   - DeckTransition (2.0.0)
+  - markymark (4.0.4)
   - Pageboy (2.4.0)
   - Realm (3.0.2):
     - Realm/Headers (= 3.0.2)
@@ -22,6 +23,7 @@ DEPENDENCIES:
   - Alamofire (~> 4.6)
   - Alamofire-SwiftyJSON
   - DeckTransition (~> 2.0)
+  - markymark
   - RealmSwift (~> 3.0.2)
   - SwiftLint (~> 0.25.0)
   - SwiftyJSON (~> 4.0.0)
@@ -33,6 +35,7 @@ SPEC CHECKSUMS:
   Alamofire-SwiftyJSON: 2b3649d57dc7bb2880fb8b86f8bb969397666916
   AutoInsetter: d90171b54341b801edd4ab68eee9eec54fdc92b7
   DeckTransition: 2300694f94fbeca2c103f365dc9dc09ffae14a4f
+  markymark: 87b1bbf9f990c88c583bab25c7cbf6754a5012c6
   Pageboy: b04cee5c1315a865fb49321129d12635e8465144
   Realm: 6f23fd1f178a09342eac21bfa7c2bf4312a7a180
   RealmSwift: 695393add1b8f9d5fa75dd16e6355cf3935f71e2
@@ -41,6 +44,6 @@ SPEC CHECKSUMS:
   Tabman: a9be97d1c75b4b7f40eec416021f614c4ccbb670
   TagListView: 669f7d4455003c877655875d34829731c4191528
 
-PODFILE CHECKSUM: fb37579a24e7e3b32c9e493ad1184965d3715287
+PODFILE CHECKSUM: d732401e39c836842b285bbc7a66da1aca7a1fcd
 
 COCOAPODS: 1.4.0

--- a/ThaiTechEventsCalendar.xcodeproj/project.pbxproj
+++ b/ThaiTechEventsCalendar.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		9FFAF9E120410338000A99FE /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9FFAF9DF20410338000A99FE /* LaunchScreen.storyboard */; };
 		9FFAF9EC20410338000A99FE /* ThaiTechEventsCalendarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FFAF9EB20410338000A99FE /* ThaiTechEventsCalendarTests.swift */; };
 		9FFAF9F720410338000A99FE /* EventFeedViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FFAF9F620410338000A99FE /* EventFeedViewControllerTests.swift */; };
+		E935F3C420455B8B0087638A /* NSAttributedStringExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E935F3C320455B8B0087638A /* NSAttributedStringExtensionsTests.swift */; };
 		E9A7B5E3204540CD002345B7 /* NSAttributedStringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A7B5E2204540CD002345B7 /* NSAttributedStringExtensions.swift */; };
 		F00AF86568834E1FEB350DC6 /* Pods_ThaiTechEventsCalendarTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5EAE1EE5FAA4624FE904C96 /* Pods_ThaiTechEventsCalendarTests.framework */; };
 /* End PBXBuildFile section */
@@ -95,6 +96,7 @@
 		9FFAF9F820410338000A99FE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A72A37BC968FFB57CD54E378 /* Pods-ThaiTechEventsCalendarTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThaiTechEventsCalendarTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ThaiTechEventsCalendarTests/Pods-ThaiTechEventsCalendarTests.release.xcconfig"; sourceTree = "<group>"; };
 		C5EAE1EE5FAA4624FE904C96 /* Pods_ThaiTechEventsCalendarTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ThaiTechEventsCalendarTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E935F3C320455B8B0087638A /* NSAttributedStringExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSAttributedStringExtensionsTests.swift; sourceTree = "<group>"; };
 		E9A7B5E2204540CD002345B7 /* NSAttributedStringExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSAttributedStringExtensions.swift; sourceTree = "<group>"; };
 		FFB6DBD4FAEDAEFB81B3824D /* Pods_ThaiTechEventsCalendar.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ThaiTechEventsCalendar.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -252,6 +254,7 @@
 				9FFAF9EB20410338000A99FE /* ThaiTechEventsCalendarTests.swift */,
 				9F4CD0D12042E33D00528E66 /* JsonParsingTests.swift */,
 				9F984D172042F08600B7BC7B /* DateUtilsTests.swift */,
+				E935F3C320455B8B0087638A /* NSAttributedStringExtensionsTests.swift */,
 				9FFAF9ED20410338000A99FE /* Info.plist */,
 			);
 			path = ThaiTechEventsCalendarTests;
@@ -632,6 +635,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9F4CD0D22042E33E00528E66 /* JsonParsingTests.swift in Sources */,
+				E935F3C420455B8B0087638A /* NSAttributedStringExtensionsTests.swift in Sources */,
 				9FFAF9EC20410338000A99FE /* ThaiTechEventsCalendarTests.swift in Sources */,
 				9F984D182042F08600B7BC7B /* DateUtilsTests.swift in Sources */,
 			);

--- a/ThaiTechEventsCalendar.xcodeproj/project.pbxproj
+++ b/ThaiTechEventsCalendar.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		9FFAF9E120410338000A99FE /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9FFAF9DF20410338000A99FE /* LaunchScreen.storyboard */; };
 		9FFAF9EC20410338000A99FE /* ThaiTechEventsCalendarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FFAF9EB20410338000A99FE /* ThaiTechEventsCalendarTests.swift */; };
 		9FFAF9F720410338000A99FE /* EventFeedViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FFAF9F620410338000A99FE /* EventFeedViewControllerTests.swift */; };
+		E9A7B5E3204540CD002345B7 /* NSAttributedStringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A7B5E2204540CD002345B7 /* NSAttributedStringExtensions.swift */; };
 		F00AF86568834E1FEB350DC6 /* Pods_ThaiTechEventsCalendarTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C5EAE1EE5FAA4624FE904C96 /* Pods_ThaiTechEventsCalendarTests.framework */; };
 /* End PBXBuildFile section */
 
@@ -94,6 +95,7 @@
 		9FFAF9F820410338000A99FE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A72A37BC968FFB57CD54E378 /* Pods-ThaiTechEventsCalendarTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ThaiTechEventsCalendarTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ThaiTechEventsCalendarTests/Pods-ThaiTechEventsCalendarTests.release.xcconfig"; sourceTree = "<group>"; };
 		C5EAE1EE5FAA4624FE904C96 /* Pods_ThaiTechEventsCalendarTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ThaiTechEventsCalendarTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E9A7B5E2204540CD002345B7 /* NSAttributedStringExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSAttributedStringExtensions.swift; sourceTree = "<group>"; };
 		FFB6DBD4FAEDAEFB81B3824D /* Pods_ThaiTechEventsCalendar.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ThaiTechEventsCalendar.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -174,6 +176,7 @@
 			children = (
 				9F1C8D5B2041595A0016E72E /* DateUtils.swift */,
 				9F4CD08D20419D2200528E66 /* ColorUtils.swift */,
+				E9A7B5E2204540CD002345B7 /* NSAttributedStringExtensions.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -563,6 +566,7 @@
 				"${BUILT_PRODUCTS_DIR}/SwiftyJSON/SwiftyJSON.framework",
 				"${BUILT_PRODUCTS_DIR}/Tabman/Tabman.framework",
 				"${BUILT_PRODUCTS_DIR}/TagListView/TagListView.framework",
+				"${BUILT_PRODUCTS_DIR}/markymark/markymark.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -576,6 +580,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftyJSON.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Tabman.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TagListView.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/markymark.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -605,6 +610,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9F4CD08A204172AE00528E66 /* EventDetailViewController.swift in Sources */,
+				E9A7B5E3204540CD002345B7 /* NSAttributedStringExtensions.swift in Sources */,
 				9F4CD08C20417D5D00528E66 /* DetailTableViewCell.swift in Sources */,
 				9F4CD0A52042881A00528E66 /* CalendarAPI.swift in Sources */,
 				9F4CD08E20419D2200528E66 /* ColorUtils.swift in Sources */,

--- a/ThaiTechEventsCalendar.xcodeproj/xcshareddata/xcschemes/ThaiTechEventsCalendar.xcscheme
+++ b/ThaiTechEventsCalendar.xcodeproj/xcshareddata/xcschemes/ThaiTechEventsCalendar.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
-   version = "1.3">
+   LastUpgradeVersion = "0920"
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -84,7 +84,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3FCBB319EEF6176C121628AA4A2047CE"
+               BlueprintIdentifier = "06376472274AEDB4573BA5F59A5A3DBF"
                BuildableName = "Pods_ThaiTechEventsCalendar.framework"
                BlueprintName = "Pods-ThaiTechEventsCalendar"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -126,7 +126,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "ABD84594EAF56DDE85A6FE615DC8F3DA"
+               BlueprintIdentifier = "6B01103B830446CB04F706C192950E63"
                BuildableName = "Realm.framework"
                BlueprintName = "Realm"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -140,7 +140,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CD8E66BE66A6D8E9B02EE5E076B37B49"
+               BlueprintIdentifier = "48C78B0E25BD60BA0E3C01B39AD6E178"
                BuildableName = "RealmSwift.framework"
                BlueprintName = "RealmSwift"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -168,7 +168,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "48B5EF6C8318EBEFC1C42923A0C450C4"
+               BlueprintIdentifier = "08684DFF4615FA08858896ABE4916E08"
                BuildableName = "Tabman.framework"
                BlueprintName = "Tabman"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -182,7 +182,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "918DEDC4A6CEE0DE0B591A4915CA745E"
+               BlueprintIdentifier = "AA42C4706C252B18C61A40D1EEE44C95"
                BuildableName = "TagListView.framework"
                BlueprintName = "TagListView"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -208,18 +208,10 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
-      <CodeCoverageTargets>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "9FFAF9D220410337000A99FE"
-            BuildableName = "ThaiTechEventsCalendar.app"
-            BlueprintName = "ThaiTechEventsCalendar"
-            ReferencedContainer = "container:ThaiTechEventsCalendar.xcodeproj">
-         </BuildableReference>
-      </CodeCoverageTargets>
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -253,11 +245,21 @@
       </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9FFAF9D220410337000A99FE"
+            BuildableName = "ThaiTechEventsCalendar.app"
+            BlueprintName = "ThaiTechEventsCalendar"
+            ReferencedContainer = "container:ThaiTechEventsCalendar.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/ThaiTechEventsCalendar.xcodeproj/xcshareddata/xcschemes/ThaiTechEventsCalendarTests.xcscheme
+++ b/ThaiTechEventsCalendar.xcodeproj/xcshareddata/xcschemes/ThaiTechEventsCalendarTests.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
-   version = "1.3">
+   LastUpgradeVersion = "0920"
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -84,7 +84,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3FCBB319EEF6176C121628AA4A2047CE"
+               BlueprintIdentifier = "06376472274AEDB4573BA5F59A5A3DBF"
                BuildableName = "Pods_ThaiTechEventsCalendar.framework"
                BlueprintName = "Pods-ThaiTechEventsCalendar"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -126,7 +126,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "ABD84594EAF56DDE85A6FE615DC8F3DA"
+               BlueprintIdentifier = "6B01103B830446CB04F706C192950E63"
                BuildableName = "Realm.framework"
                BlueprintName = "Realm"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -140,7 +140,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CD8E66BE66A6D8E9B02EE5E076B37B49"
+               BlueprintIdentifier = "48C78B0E25BD60BA0E3C01B39AD6E178"
                BuildableName = "RealmSwift.framework"
                BlueprintName = "RealmSwift"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -168,7 +168,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "48B5EF6C8318EBEFC1C42923A0C450C4"
+               BlueprintIdentifier = "08684DFF4615FA08858896ABE4916E08"
                BuildableName = "Tabman.framework"
                BlueprintName = "Tabman"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
@@ -182,9 +182,23 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "918DEDC4A6CEE0DE0B591A4915CA745E"
+               BlueprintIdentifier = "AA42C4706C252B18C61A40D1EEE44C95"
                BuildableName = "TagListView.framework"
                BlueprintName = "TagListView"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B1B0738501507B4084D184F107B3F50A"
+               BuildableName = "markymark.framework"
+               BlueprintName = "markymark"
                ReferencedContainer = "container:Pods/Pods.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -194,18 +208,10 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
-      <CodeCoverageTargets>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "9FFAF9D220410337000A99FE"
-            BuildableName = "ThaiTechEventsCalendar.app"
-            BlueprintName = "ThaiTechEventsCalendar"
-            ReferencedContainer = "container:ThaiTechEventsCalendar.xcodeproj">
-         </BuildableReference>
-      </CodeCoverageTargets>
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -228,22 +234,23 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "88E9EC28B8B46C3631E6B242B50F4442"
-            BuildableName = "Alamofire.framework"
-            BlueprintName = "Alamofire"
-            ReferencedContainer = "container:Pods/Pods.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9FFAF9D220410337000A99FE"
+            BuildableName = "ThaiTechEventsCalendar.app"
+            BlueprintName = "ThaiTechEventsCalendar"
+            ReferencedContainer = "container:ThaiTechEventsCalendar.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/ThaiTechEventsCalendar/Utils/NSAttributedStringExtensions.swift
+++ b/ThaiTechEventsCalendar/Utils/NSAttributedStringExtensions.swift
@@ -1,0 +1,28 @@
+//
+//  NSAttributedStringExtensions.swift
+//  ThaiTechEventsCalendar
+//
+//  Created by WorametMuangsiri on 2018/02/27.
+//  Copyright © 2018 WM. All rights reserved.
+//
+
+import Foundation
+import markymark
+
+extension NSAttributedString {
+
+    class func from(_ markdown: String) -> NSAttributedString {
+        let markyMark = MarkyMark(build: {
+            $0.setFlavor(ContentfulFlavor())
+        })
+
+        var styling = DefaultStyling()
+        styling.linkStyling.textColor = UIColor.TTOrange()
+        styling.paragraphStyling.baseFont = UIFont.preferredFont(forTextStyle: UIFontTextStyle.body)
+        styling.listStyling.baseFont = UIFont.preferredFont(forTextStyle: UIFontTextStyle.body)
+        let configuration = MarkDownToAttributedStringConverterConfiguration(styling: styling)
+        let converter = MarkDownConverter(configuration: configuration)
+        let str = markyMark.parseMarkDown(markdown)
+        return converter.convert(str)
+    }
+}

--- a/ThaiTechEventsCalendar/Views/Cells/EventTableViewCell.swift
+++ b/ThaiTechEventsCalendar/Views/Cells/EventTableViewCell.swift
@@ -49,7 +49,7 @@ extension EventTableViewCell: Updatable {
 
     func updateUIWith(_ event: Event) {
         titleLabel.text = event.title
-        summaryLabel.text = event.summary
+        summaryLabel.attributedText = NSAttributedString.from(event.summary)
 
         let start = dateFormatter.string(from: event.start)
         let startDay = weekdayFormatter.string(from: event.start)

--- a/ThaiTechEventsCalendar/Views/Cells/SummaryTableViewCell.swift
+++ b/ThaiTechEventsCalendar/Views/Cells/SummaryTableViewCell.swift
@@ -28,14 +28,14 @@ class SummaryTableViewCell: UITableViewCell {
 extension SummaryTableViewCell: Updatable {
 
     func updateUIWith(_ event: Event) {
-        summaryLabel?.text = event.summary
+        summaryLabel?.attributedText = NSAttributedString.from(event.summary)
 
         if event.summary.isEmpty {
             summaryLabel.isHidden = true
             grayView.isHidden = true
         }
 
-        descLabel.text = event.desc
+        descLabel.attributedText = NSAttributedString.from(event.desc)
     }
 
 }

--- a/ThaiTechEventsCalendarTests/NSAttributedStringExtensionsTests.swift
+++ b/ThaiTechEventsCalendarTests/NSAttributedStringExtensionsTests.swift
@@ -1,0 +1,22 @@
+//
+//  NSAttributedStringExtensionsTests.swift
+//  ThaiTechEventsCalendarTests
+//
+//  Created by WorametMuangsiri on 2018/02/27.
+//  Copyright © 2018 WM. All rights reserved.
+//
+
+import XCTest
+@testable import ThaiTechEventsCalendar
+
+class NSAttributedStringExtensionsTests: XCTestCase {
+
+    func testAttributedStringFromMarkdownStringNotNil() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        let markdownString = "- \"Every language needs its underscore: FP in Python\" - Alexander Schepanovski.\n- \"Panel Discussion: What it's like to a female in Thai tech\" - To help support the upcoming [Django Girls one day workshop 10 March 2018](https://djangogirls.org/bangkok/).\n- Short talks and lightning talks\n\nMonthly meetup for those using python, learning python of just py-curious. Python is one of more popular programming languages in the word and rising further, being used in fields such as web, science, big data, dev-ops and digital entertainment. We to have talks from beginners to advance and provide a friendly atmosphere to meet and network with your fellow pythonistas."
+        let attributedString = NSAttributedString.from(markdownString)
+        XCTAssertNotNil(attributedString)
+    }
+
+}

--- a/ThaiTechEventsCalendarUITests/EventFeedViewControllerTests.swift
+++ b/ThaiTechEventsCalendarUITests/EventFeedViewControllerTests.swift
@@ -26,8 +26,10 @@ class EventFeedViewControllerTests: XCTestCase {
         XCTAssertFalse(detailTable.exists)
 
         cell.tap()
+        let exists = NSPredicate(format: "exists == 1")
 
-        XCTAssertTrue(detailTable.exists)
+        expectation(for: exists, evaluatedWith: detailTable, handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
 
 }

--- a/ThaiTechEventsCalendarUITests/EventTabViewControllerTests.swift
+++ b/ThaiTechEventsCalendarUITests/EventTabViewControllerTests.swift
@@ -33,8 +33,10 @@ class EventTabViewControllerTests: XCTestCase {
         XCTAssertTrue(app.navigationBars["Upcoming events"].exists)
         let table = app.tables.firstMatch
         table.swipeLeft()
-        sleep(1)
-        XCTAssertTrue(app.navigationBars["Past events"].exists, "Past events tab should appear.")
+
+        let exists = NSPredicate(format: "exists == 1")
+        expectation(for: exists, evaluatedWith: app.navigationBars["Past events"], handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
 
     func testSwipeRightFromUpComingEvents() {
@@ -42,8 +44,10 @@ class EventTabViewControllerTests: XCTestCase {
         XCTAssertTrue(app.navigationBars["Upcoming events"].exists)
         let table = app.tables.firstMatch
         table.swipeRight()
-        sleep(1)
-        XCTAssertTrue(app.navigationBars["Upcoming events"].exists, "Nothing should be changed.")
+
+        let exists = NSPredicate(format: "exists == 1")
+        expectation(for: exists, evaluatedWith: app.navigationBars["Upcoming events"], handler: nil)
+        waitForExpectations(timeout: 5, handler: nil)
     }
 
     func testSwipeRightFromPastEvents() {


### PR DESCRIPTION
## What's in this PR:
- Added markdown support for `summaryLabel`, `descLabel` in `SummaryTableViewCell` and `EventTableViewCell`
- Added `NSAttributedString` extension for parsing markdown -> AttributedString

<img width="528" alt="screen shot 2018-02-27 at 17 29 30" src="https://user-images.githubusercontent.com/500289/36720168-91c533bc-1bea-11e8-8ee2-e1e2cdfaa723.png">