### PR TITLE
Refactor calendar API

### DIFF
--- a/ThaiTechEventsCalendar.xcodeproj/project.pbxproj
+++ b/ThaiTechEventsCalendar.xcodeproj/project.pbxproj
@@ -1134,6 +1134,7 @@
 				CODE_SIGN_ENTITLEMENTS = ThaiTechEventsCalendar/ThaiTechEventsCalendar.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
+				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = PRXSGPVD4P;
 				INFOPLIST_FILE = ThaiTechEventsCalendar/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;

--- a/ThaiTechEventsCalendar/Networks/CalendarAPI.swift
+++ b/ThaiTechEventsCalendar/Networks/CalendarAPI.swift
@@ -50,38 +50,30 @@ struct CalendarAPI {
 
 extension CalendarAPI {
     // MARK: - Events filter (refactorable)
-    func events(on date: Date) -> Results<Event>? {
+    func events(that predicate: NSPredicate,ascending isAscending: Bool) -> Results<Event>? {
         guard let realm = try? Realm() else {
             return nil
         }
-        let tmr = date.addingTimeInterval(24 * 60 * 60)
-        let thatDatePredicate = NSPredicate(format: "start >= %@ AND end <= %@", date as NSDate, tmr as NSDate)
+        
         return realm
             .objects(Event.self)
-            .filter(thatDatePredicate)
-            .sorted(byKeyPath: "start", ascending: true)
+            .filter(predicate)
+            .sorted(byKeyPath: "start", ascending: isAscending)
+    }
+
+    func events(on date: Date) -> Results<Event>? {
+        let tmr = date.addingTimeInterval(24 * 60 * 60)
+        let onToday = NSPredicate(format: "start >= %@ AND end <= %@", date as NSDate, tmr as NSDate)
+        return events(that: onToday, ascending: true)
     }
 
     func upcomingEvents() -> Results<Event>? {
-        guard let realm = try? Realm() else {
-            return nil
-        }
-
-        let upcomingPredicate = NSPredicate(format: "start >= %@", Date().gregorianDate() as NSDate)
-        return realm
-            .objects(Event.self)
-            .filter(upcomingPredicate)
-            .sorted(byKeyPath: "start", ascending: true)
+        let upcoming = NSPredicate(format: "start >= %@", Date().gregorianDate() as NSDate)
+        return events(that: upcoming, ascending: true)
     }
 
     func pastEvents() -> Results<Event>? {
-        guard let realm = try? Realm() else {
-            return nil
-        }
-        let pastPredicate = NSPredicate(format: "start < %@", Date().gregorianDate() as NSDate)
-        return realm
-            .objects(Event.self)
-            .filter(pastPredicate)
-            .sorted(byKeyPath: "start", ascending: false)
+        let alreadyPassed = NSPredicate(format: "start < %@", Date().gregorianDate() as NSDate)
+        return events(that: alreadyPassed, ascending: false)
     }
 }

--- a/ThaiTechEventsCalendar/Networks/CalendarAPI.swift
+++ b/ThaiTechEventsCalendar/Networks/CalendarAPI.swift
@@ -12,11 +12,13 @@ import SwiftyJSON
 import Alamofire_SwiftyJSON
 import Alamofire
 
+// MARK: - Constants
 struct TTConstant {
     static let baseAPIURL = "https://thaiprogrammer-tech-events-calendar.spacet.me"
     static let baseURL = "https://calendar.thaiprogrammer.org/event/"
 }
 
+// MARK: Calendar network API
 struct CalendarAPI {
 
     func fetchCalendarFromNetwork() {
@@ -25,21 +27,13 @@ struct CalendarAPI {
 
     func fetchCalendarFromNetwork(success: (() -> Void)?,
                                   failure: (() -> Void)?) {
-        guard let realm = try? Realm() else {
-            failure?()
-            return
-        }
+        guard let realm = try? Realm() else { failure?(); return }
 
         Alamofire.request(TTConstant.baseAPIURL+"/calendar.json").responseSwiftyJSON { dataResponse in
-            if dataResponse.error != nil {
-                failure?()
-                return
-            }
-            guard let json = dataResponse.value else {
-                failure?()
-                return
-            }
-            try! realm.write {
+            if dataResponse.error != nil { failure?(); return }
+            guard let json = dataResponse.value else { failure?(); return }
+
+            try? realm.write {
                 json.arrayValue.forEach({ realm.add(Event($0), update: true) })
                 success?()
             }
@@ -48,13 +42,12 @@ struct CalendarAPI {
 
 }
 
+// MARK: - Events query
 extension CalendarAPI {
-    // MARK: - Events filter (refactorable)
-    func events(that predicate: NSPredicate,ascending isAscending: Bool) -> Results<Event>? {
-        guard let realm = try? Realm() else {
-            return nil
-        }
-        
+    // MARK: - Events by start date
+    func events(when predicate: NSPredicate, ascending isAscending: Bool) -> Results<Event>? {
+        guard let realm = try? Realm() else { return nil }
+
         return realm
             .objects(Event.self)
             .filter(predicate)
@@ -63,17 +56,17 @@ extension CalendarAPI {
 
     func events(on date: Date) -> Results<Event>? {
         let tmr = date.addingTimeInterval(24 * 60 * 60)
-        let onToday = NSPredicate(format: "start >= %@ AND end <= %@", date as NSDate, tmr as NSDate)
-        return events(that: onToday, ascending: true)
+        let today = NSPredicate(format: "start >= %@ AND end <= %@", date as NSDate, tmr as NSDate)
+        return events(when: today, ascending: true)
     }
 
     func upcomingEvents() -> Results<Event>? {
         let upcoming = NSPredicate(format: "start >= %@", Date().gregorianDate() as NSDate)
-        return events(that: upcoming, ascending: true)
+        return events(when: upcoming, ascending: true)
     }
 
     func pastEvents() -> Results<Event>? {
         let alreadyPassed = NSPredicate(format: "start < %@", Date().gregorianDate() as NSDate)
-        return events(that: alreadyPassed, ascending: false)
+        return events(when: alreadyPassed, ascending: false)
     }
 }

--- a/ThaiTechEventsCalendarTests/DateUtilsTests.swift
+++ b/ThaiTechEventsCalendarTests/DateUtilsTests.swift
@@ -12,14 +12,40 @@ import SwiftyJSON
 
 class DateUtilsTests: XCTestCase {
 
-    override func setUp() {
-        super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    func testDateString() {
+        var dateComponents = DateComponents()
+        dateComponents.year = 2018
+        dateComponents.month = 3
+        dateComponents.day = 31
+        dateComponents.timeZone = TimeZone(abbreviation: "GMT+7")
+        var dateComponents2 = DateComponents()
+        dateComponents2.year = 2018
+        dateComponents2.month = 4
+        dateComponents2.day = 22
+        dateComponents2.timeZone = TimeZone(abbreviation: "GMT+7")
+        let userCalendar = Calendar(identifier: .gregorian)
+        let march_31 = userCalendar.date(from: dateComponents)!
+        let april_22 = userCalendar.date(from: dateComponents2)!
+        XCTAssertEqual(DateUtils.dateString(fromDate: march_31, toDate: april_22), "March 31 (Sat) ~ April 22 (Sun)")
     }
 
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
+    func testDateStringSingleDay() {
+        var dateComponents = DateComponents()
+        dateComponents.year = 2018
+        dateComponents.month = 3
+        dateComponents.day = 31
+        dateComponents.timeZone = TimeZone(abbreviation: "GMT+7")
+
+        var dateComponents2 = DateComponents()
+        dateComponents2.year = 2018
+        dateComponents2.month = 3
+        dateComponents2.day = 31
+        dateComponents2.timeZone = TimeZone(abbreviation: "GMT+7")
+
+        let userCalendar = Calendar(identifier: .gregorian)
+        let march_31 = userCalendar.date(from: dateComponents)!
+        let anotherMarch_31 = userCalendar.date(from: dateComponents2)!
+        XCTAssertEqual(DateUtils.dateString(fromDate: march_31, toDate: anotherMarch_31), "March 31 (Sat)")
     }
 
     func testParseDateFromJSONShouldNotBeNil() {


### PR DESCRIPTION
- Moved redundant logic to `func events(when predicate: NSPredicate, ascending isAscending: Bool) -> Results<Event>?`
- Added unit-tests for `DateUtils.dateString(:)`